### PR TITLE
US-01.7: Regra Remoção de Foco Visual (CSS)

### DIFF
--- a/examples/focus-visible-html-test.html
+++ b/examples/focus-visible-html-test.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Teste de Foco Visivel em HTML</title>
+</head>
+
+<body>
+  <h1>Exemplo de foco visivel (HTML)</h1>
+
+  <!-- Violacao: elemento focavel com remocao de foco inline sem alternativa -->
+  <button style="outline: none;">Botao sem indicador de foco</button>
+
+  <!-- Conforme: elemento focavel com alternativa visual -->
+  <a href="/home" style="outline: none; box-shadow: 0 0 0 3px #005fcc;">Link com indicador alternativo</a>
+
+  <!-- Inaplicavel: fora da ordem sequencial -->
+  <a href="/contato" tabindex="-1" style="outline:none;">Link fora da navegacao sequencial</a>
+</body>
+
+</html>

--- a/examples/focus-visual-removal-test.css
+++ b/examples/focus-visual-removal-test.css
@@ -1,0 +1,13 @@
+button:focus {
+  outline: none;
+}
+
+.card:focus-visible {
+  outline: 0;
+}
+
+/* Caso conforme: remove outline, mas fornece alternativa visual */
+.link:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px #005fcc;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,8 @@ import { validateHeadersOrder } from './rules/headersRules';
 import { validateZoomCapability } from './rules/zoomRules';
 import { validateJustifiedCss } from './rules/justifyRules';
 import { validateNonInteractiveClickableElements } from './rules/nonInteractiveClickableRules';
+import { validateFocusVisualRemoval } from './rules/focusRules';
+import { validateHtmlFocusVisible } from './rules/focusHtmlRules';
 import { RuleError } from './rules/types';
 
 let timeout: NodeJS.Timeout | undefined = undefined;
@@ -68,10 +70,12 @@ function processValidation(document: vscode.TextDocument): void {
 		errors.push(...validateHeadersOrder(text));
 		errors.push(...validateZoomCapability(text));
 		errors.push(...validateNonInteractiveClickableElements(text));
+		errors.push(...validateHtmlFocusVisible(text));
 	}
 
 	if (language === 'css') {
 		errors.push(...validateJustifiedCss(text));
+		errors.push(...validateFocusVisualRemoval(text));
 	}
 
 	errors.forEach(error => {

--- a/src/rules/focusHtmlRules.ts
+++ b/src/rules/focusHtmlRules.ts
@@ -1,0 +1,109 @@
+import { RuleError } from "./types";
+import { parseHtmlAttributes } from "./utils/htmlAttributes";
+
+// Captura tags de abertura HTML e o nome da tag no grupo 1.
+const OPENING_TAG_REGEX = /<([a-z][\w:-]*)\b[^>]*>/gi;
+
+// Detecta remocao de foco no style inline (outline: none ou outline: 0/0px).
+const OUTLINE_REMOVAL_REGEX = /\boutline\s*:\s*(none|0(?:px)?)(?![\w-])/i;
+
+// Detecta outline inline com valor visivel (diferente de none/0).
+const VISIBLE_OUTLINE_REGEX = /\boutline\s*:\s*(?!\s*(none\b|0(?:px)?\b))[^;}{]+/i;
+
+// Detecta box-shadow inline como alternativa de foco (exceto none).
+const VISIBLE_BOX_SHADOW_REGEX = /\bbox-shadow\s*:\s*(?!\s*none\b)[^;}{]+/i;
+
+// Detecta border inline com valor visivel no shorthand (exceto none/0).
+const VISIBLE_BORDER_REGEX = /\bborder\s*:\s*(?!\s*(none\b|0(?:px)?\b))[^;}{]+/i;
+
+// Detecta declaracoes border-color/style/width no style inline.
+const VISIBLE_BORDER_PART_REGEX = /\bborder-(color|style|width)\s*:\s*[^;}{]+/i;
+
+// Detecta text-decoration inline visivel (diferente de none).
+const VISIBLE_TEXT_DECORATION_REGEX = /\btext-decoration\s*:\s*(?!\s*none\b)[^;}{]+/i;
+
+/**
+ * Verifica se existe indicador visual alternativo no style inline.
+ */
+function hasAlternativeFocusIndicator(style: string): boolean {
+  return (
+    VISIBLE_OUTLINE_REGEX.test(style) ||
+    VISIBLE_BOX_SHADOW_REGEX.test(style) ||
+    VISIBLE_BORDER_REGEX.test(style) ||
+    VISIBLE_BORDER_PART_REGEX.test(style) ||
+    VISIBLE_TEXT_DECORATION_REGEX.test(style)
+  );
+}
+
+/**
+ * Verifica se um elemento participa da navegacao sequencial por teclado.
+ */
+function isSequentiallyFocusable(tagName: string, attrs: Record<string, string>): boolean {
+  const tabindexRaw = attrs["tabindex"];
+
+  if (typeof tabindexRaw === "string") {
+    const parsedTabindex = Number.parseInt(tabindexRaw, 10);
+
+    if (!Number.isNaN(parsedTabindex)) {
+      return parsedTabindex >= 0;
+    }
+  }
+
+  const normalizedTagName = tagName.toLowerCase();
+
+  if (normalizedTagName === "a") {
+    return typeof attrs["href"] === "string" && attrs["href"].trim() !== "";
+  }
+
+  if (normalizedTagName === "button" || normalizedTagName === "select" || normalizedTagName === "textarea") {
+    return true;
+  }
+
+  if (normalizedTagName === "input") {
+    return attrs["type"]?.toLowerCase() !== "hidden";
+  }
+
+  return false;
+}
+
+/**
+ * Valida elementos focaveis em HTML com remocao de foco visual inline sem alternativa.
+ * @param text O conteudo HTML a ser analisado.
+ */
+export function validateHtmlFocusVisible(text: string): RuleError[] {
+  const errors: RuleError[] = [];
+
+  OPENING_TAG_REGEX.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = OPENING_TAG_REGEX.exec(text)) !== null) {
+    const entireTag = match[0];
+    const tagName = match[1].toLowerCase();
+    const attrs = parseHtmlAttributes(entireTag);
+
+    if (!isSequentiallyFocusable(tagName, attrs)) {
+      continue;
+    }
+
+    const style = attrs["style"];
+    if (!style) {
+      continue;
+    }
+
+    if (!OUTLINE_REMOVAL_REGEX.test(style)) {
+      continue;
+    }
+
+    if (hasAlternativeFocusIndicator(style)) {
+      continue;
+    }
+
+    errors.push({
+      tag: entireTag,
+      index: match.index,
+      message: "Erro de Acessibilidade: Elemento focavel remove o foco visual inline (outline: none/0) sem indicador alternativo.",
+    });
+  }
+
+  return errors;
+}

--- a/src/rules/focusRules.ts
+++ b/src/rules/focusRules.ts
@@ -1,0 +1,74 @@
+import { RuleError } from "./types";
+
+// Divide o CSS em blocos "seletor { declaracoes }" para avaliacao por contexto.
+const CSS_BLOCK_REGEX = /([^{}]+)\{([^}]*)\}/g;
+
+// Detecta remocao explicita do indicador padrao de foco (outline: none ou outline: 0/0px).
+const OUTLINE_REMOVAL_REGEX = /\boutline\s*:\s*(none|0(?:px)?)(?![\w-])/gi;
+
+// Detecta outline com valor visivel (qualquer valor diferente de none/0).
+const VISIBLE_OUTLINE_REGEX = /\boutline\s*:\s*(?!\s*(none\b|0(?:px)?\b))[^;}{]+/i;
+
+// Detecta box-shadow visivel como alternativa de foco (exceto none).
+const VISIBLE_BOX_SHADOW_REGEX = /\bbox-shadow\s*:\s*(?!\s*none\b)[^;}{]+/i;
+
+// Detecta borda visivel no shorthand border (exceto none/0).
+const VISIBLE_BORDER_REGEX = /\bborder\s*:\s*(?!\s*(none\b|0(?:px)?\b))[^;}{]+/i;
+
+// Detecta ajustes de border-color/style/width que podem criar indicador visual.
+const VISIBLE_BORDER_PART_REGEX = /\bborder-(color|style|width)\s*:\s*[^;}{]+/i;
+
+// Detecta text-decoration visivel (substitui o indicador quando nao e none).
+const VISIBLE_TEXT_DECORATION_REGEX = /\btext-decoration\s*:\s*(?!\s*none\b)[^;}{]+/i;
+
+/**
+ * Verifica se existe indicador visual alternativo no mesmo bloco CSS.
+ */
+function hasAlternativeFocusIndicator(declarations: string): boolean {
+  return (
+    VISIBLE_OUTLINE_REGEX.test(declarations) ||
+    VISIBLE_BOX_SHADOW_REGEX.test(declarations) ||
+    VISIBLE_BORDER_REGEX.test(declarations) ||
+    VISIBLE_BORDER_PART_REGEX.test(declarations) ||
+    VISIBLE_TEXT_DECORATION_REGEX.test(declarations)
+  );
+}
+
+/**
+ * Valida remocao de foco visual em CSS sem alternativa de indicador visivel.
+ * @param text O conteudo CSS a ser analisado.
+ */
+export function validateFocusVisualRemoval(text: string): RuleError[] {
+  const errors: RuleError[] = [];
+
+  // Remove comentarios preservando tamanho para manter indices consistentes.
+  const cssWithoutComments = text.replace(/\/\*[\s\S]*?\*\//g, (comment) => " ".repeat(comment.length));
+
+  CSS_BLOCK_REGEX.lastIndex = 0;
+
+  let blockMatch: RegExpExecArray | null;
+  while ((blockMatch = CSS_BLOCK_REGEX.exec(cssWithoutComments)) !== null) {
+    const selector = blockMatch[1].trim();
+    const declarations = blockMatch[2];
+    const blockStartIndex = blockMatch.index;
+    const declarationsStartIndex = blockStartIndex + blockMatch[0].indexOf("{") + 1;
+
+    OUTLINE_REMOVAL_REGEX.lastIndex = 0;
+    const hasAlternativeIndicator = hasAlternativeFocusIndicator(declarations);
+
+    if (hasAlternativeIndicator) {
+      continue;
+    }
+
+    let outlineMatch: RegExpExecArray | null;
+    while ((outlineMatch = OUTLINE_REMOVAL_REGEX.exec(declarations)) !== null) {
+      errors.push({
+        tag: `${selector} { ${outlineMatch[0]} }`,
+        index: declarationsStartIndex + outlineMatch.index,
+        message: "Erro de Acessibilidade: Evite remover o foco visual (outline: none/0) sem indicador alternativo visivel.",
+      });
+    }
+  }
+
+  return errors;
+}

--- a/src/test/rules/focusHtmlRules.test.ts
+++ b/src/test/rules/focusHtmlRules.test.ts
@@ -1,0 +1,83 @@
+import * as assert from 'assert';
+import { validateHtmlFocusVisible } from '../../rules/focusHtmlRules';
+import { TestCase } from '../../rules/types';
+
+type FocusHtmlTestCase = TestCase<number> & {
+  category: 'Conforme' | 'Violacao' | 'Inaplicavel';
+};
+
+function runFocusHtmlRuleTests() {
+  console.log('Iniciando Testes Unitarios: Regra de Foco Visivel em HTML...');
+
+  const testCases: FocusHtmlTestCase[] = [
+    {
+      name: 'link com href sem remocao de foco inline',
+      category: 'Conforme',
+      html: '<a href="/home">Home</a>',
+      expected: 0,
+    },
+    {
+      name: 'span com tabindex=0 sem remocao de foco inline',
+      category: 'Conforme',
+      html: '<span tabindex="0">Item focavel</span>',
+      expected: 0,
+    },
+    {
+      name: 'botao focavel com outline none sem alternativa',
+      category: 'Violacao',
+      html: '<button style="outline: none;">Salvar</button>',
+      expected: 1,
+    },
+    {
+      name: 'link focavel com outline 0 sem alternativa',
+      category: 'Violacao',
+      html: '<a href="/x" style="outline:0;">Link</a>',
+      expected: 1,
+    },
+    {
+      name: 'outline none com box-shadow alternativo',
+      category: 'Conforme',
+      html: '<button style="outline:none; box-shadow: 0 0 0 3px #005fcc;">Salvar</button>',
+      expected: 0,
+    },
+    {
+      name: 'inaplicavel sem elementos focaveis',
+      category: 'Inaplicavel',
+      html: '<span>Apenas texto</span>',
+      expected: 0,
+    },
+    {
+      name: 'inaplicavel com tabindex -1 fora da ordem sequencial',
+      category: 'Inaplicavel',
+      html: '<a href="/x" tabindex="-1" style="outline:none;">Link fora da ordem</a>',
+      expected: 0,
+    },
+  ];
+
+  let passedCount = 0;
+
+  testCases.forEach(testCase => {
+    const results = validateHtmlFocusVisible(testCase.html);
+    const observed = results.length;
+
+    try {
+      assert.strictEqual(observed, testCase.expected);
+      console.log(
+        `OK | Categoria: ${testCase.category} | Caso: ${testCase.name} | esperado=${testCase.expected} encontrado=${observed}`
+      );
+      passedCount++;
+    } catch (err) {
+      console.error(
+        `ERRO | Categoria: ${testCase.category} | Caso: ${testCase.name} | esperado=${testCase.expected} encontrado=${observed}`
+      );
+    }
+  });
+
+  console.log(`\nResultado Final: ${passedCount}/${testCases.length} testes passaram.\n`);
+
+  if (passedCount !== testCases.length) {
+    process.exit(1);
+  }
+}
+
+runFocusHtmlRuleTests();

--- a/src/test/rules/focusRules.test.ts
+++ b/src/test/rules/focusRules.test.ts
@@ -1,0 +1,89 @@
+import * as assert from 'assert';
+import { validateFocusVisualRemoval } from '../../rules/focusRules';
+import { TestCase } from '../../rules/types';
+
+type FocusTestCase = TestCase<number> & {
+  category: 'Conforme' | 'Violacao' | 'Inaplicavel';
+};
+
+function runFocusRuleTests() {
+  console.log('Iniciando Testes Unitarios: Regra de Remocao de Foco Visual...');
+
+  const testCases: FocusTestCase[] = [
+    {
+      name: 'outline none sem alternativa em focus',
+      category: 'Violacao',
+      html: 'button:focus { outline: none; }',
+      expected: 1,
+    },
+    {
+      name: 'outline 0 sem alternativa em focus-visible',
+      category: 'Violacao',
+      html: '.btn:focus-visible { outline: 0; }',
+      expected: 1,
+    },
+    {
+      name: 'outline none com box-shadow alternativo',
+      category: 'Conforme',
+      html: 'button:focus { outline: none; box-shadow: 0 0 0 3px #005fcc; }',
+      expected: 0,
+    },
+    {
+      name: 'outline 0 com border alternativo',
+      category: 'Conforme',
+      html: '.link:focus { outline: 0; border: 2px solid #111; }',
+      expected: 0,
+    },
+    {
+      name: 'outline positivo sem remocao',
+      category: 'Conforme',
+      html: '.field:focus { outline: 2px solid #000; }',
+      expected: 0,
+    },
+    {
+      name: 'sem declaracao de outline',
+      category: 'Inaplicavel',
+      html: '.box { color: red; }',
+      expected: 0,
+    },
+    {
+      name: 'outline none em comentario nao deve contar',
+      category: 'Inaplicavel',
+      html: '/* .x:focus { outline: none; } */ .x { color: #333; }',
+      expected: 0,
+    },
+    {
+      name: 'duas remocoes sem alternativa',
+      category: 'Violacao',
+      html: '.a:focus { outline: none; } .b:focus { outline: 0; }',
+      expected: 2,
+    },
+  ];
+
+  let passedCount = 0;
+
+  testCases.forEach(testCase => {
+    const results = validateFocusVisualRemoval(testCase.html);
+    const observed = results.length;
+
+    try {
+      assert.strictEqual(observed, testCase.expected);
+      console.log(
+        `OK | Categoria: ${testCase.category} | Caso: ${testCase.name} | esperado=${testCase.expected} encontrado=${observed}`
+      );
+      passedCount++;
+    } catch (err) {
+      console.error(
+        `ERRO | Categoria: ${testCase.category} | Caso: ${testCase.name} | esperado=${testCase.expected} encontrado=${observed}`
+      );
+    }
+  });
+
+  console.log(`\nResultado Final: ${passedCount}/${testCases.length} testes passaram.\n`);
+
+  if (passedCount !== testCases.length) {
+    process.exit(1);
+  }
+}
+
+runFocusRuleTests();


### PR DESCRIPTION
Localizar declarações CSS que removam o indicador de foco padrão (outline: none ou outline: 0) sem prover uma alternativa visual acessível. Closes #8 