### PR TITLE
US-01.8: Regra Idioma da Página Ausente (HTML)

### DIFF
--- a/examples/page-language-missing-test.html
+++ b/examples/page-language-missing-test.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Teste de Idioma da Pagina Ausente</title>
+</head>
+
+<body>
+  <h1>Exemplo de erro de idioma da pagina</h1>
+  <p>Este arquivo deve disparar a regra por falta de atributo lang na tag html.</p>
+</body>
+
+</html>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { validateJustifiedCss } from './rules/justifyRules';
 import { validateNonInteractiveClickableElements } from './rules/nonInteractiveClickableRules';
 import { validateFocusVisualRemoval } from './rules/focusRules';
 import { validateHtmlFocusVisible } from './rules/focusHtmlRules';
+import { validatePageLanguage } from './rules/languageRules';
 import { RuleError } from './rules/types';
 
 let timeout: NodeJS.Timeout | undefined = undefined;
@@ -71,6 +72,7 @@ function processValidation(document: vscode.TextDocument): void {
 		errors.push(...validateZoomCapability(text));
 		errors.push(...validateNonInteractiveClickableElements(text));
 		errors.push(...validateHtmlFocusVisible(text));
+		errors.push(...validatePageLanguage(text));
 	}
 
 	if (language === 'css') {

--- a/src/rules/languageRules.ts
+++ b/src/rules/languageRules.ts
@@ -1,0 +1,32 @@
+import { RuleError } from "./types";
+import { parseHtmlAttributes } from "./utils/htmlAttributes";
+
+// Captura a tag raiz <html ...> para validar o idioma padrão da pagina.
+const HTML_ROOT_TAG_REGEX = /<html\b[^>]*>/i;
+
+/**
+ * Valida se a pagina HTML define o atributo lang na tag raiz.
+ * @param text O conteudo HTML a ser analisado.
+ */
+export function validatePageLanguage(text: string): RuleError[] {
+  const errors: RuleError[] = [];
+
+  const rootMatch = HTML_ROOT_TAG_REGEX.exec(text);
+  if (!rootMatch) {
+    return errors;
+  }
+
+  const htmlTag = rootMatch[0];
+  const attrs = parseHtmlAttributes(htmlTag);
+  const lang = attrs["lang"]?.trim();
+
+  if (!lang) {
+    errors.push({
+      tag: htmlTag,
+      index: rootMatch.index,
+      message: "Erro de Acessibilidade: A tag <html> deve definir o atributo lang com o idioma da pagina.",
+    });
+  }
+
+  return errors;
+}

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -7,12 +7,3 @@ export interface RuleError {
   index: number;
   message: string;
 }
-
-/**
- * Interface genérica para casos de teste de regras de validação.
- */
-export interface TestCase<T = string> {
-  name: string;
-  html: string;
-  expected: T;
-}

--- a/src/test/rules/focusHtmlRules.test.ts
+++ b/src/test/rules/focusHtmlRules.test.ts
@@ -1,15 +1,11 @@
 import * as assert from 'assert';
 import { validateHtmlFocusVisible } from '../../rules/focusHtmlRules';
-import { TestCase } from '../../rules/types';
-
-type FocusHtmlTestCase = TestCase<number> & {
-  category: 'Conforme' | 'Violacao' | 'Inaplicavel';
-};
+import { TestCase } from './testTypes';
 
 function runFocusHtmlRuleTests() {
   console.log('Iniciando Testes Unitarios: Regra de Foco Visivel em HTML...');
 
-  const testCases: FocusHtmlTestCase[] = [
+  const testCases: TestCase<number>[] = [
     {
       name: 'link com href sem remocao de foco inline',
       category: 'Conforme',

--- a/src/test/rules/focusRules.test.ts
+++ b/src/test/rules/focusRules.test.ts
@@ -1,15 +1,11 @@
 import * as assert from 'assert';
 import { validateFocusVisualRemoval } from '../../rules/focusRules';
-import { TestCase } from '../../rules/types';
-
-type FocusTestCase = TestCase<number> & {
-  category: 'Conforme' | 'Violacao' | 'Inaplicavel';
-};
+import { TestCase } from './testTypes';
 
 function runFocusRuleTests() {
   console.log('Iniciando Testes Unitarios: Regra de Remocao de Foco Visual...');
 
-  const testCases: FocusTestCase[] = [
+  const testCases: TestCase<number>[] = [
     {
       name: 'outline none sem alternativa em focus',
       category: 'Violacao',

--- a/src/test/rules/headersRules.test.ts
+++ b/src/test/rules/headersRules.test.ts
@@ -1,15 +1,11 @@
 import * as assert from 'assert';
 import { validateHeadersOrder } from '../../rules/headersRules';
-import { TestCase } from '../../rules/types';
-
-type HeadersTestCase = TestCase<number> & {
-  category: 'Conforme' | 'Violacao' | 'Inaplicavel';
-};
+import { TestCase } from './testTypes';
 
 function runHeadersTests() {
   console.log('Iniciando Testes Unitarios: Regras de Hierarquia de Cabecalhos...');
 
-  const testCases: HeadersTestCase[] = [
+  const testCases: TestCase<number>[] = [
     { name: 'Apenas um cabecalho h1', category: 'Conforme', html: '<h1>Titulo</h1>', expected: 0 },
     { name: 'Apenas um cabecalho h4', category: 'Conforme', html: '<h4>Secao isolada</h4>', expected: 0 },
     { name: 'Apenas um cabecalho h6', category: 'Conforme', html: '<h6>Rodape isolado</h6>', expected: 0 },

--- a/src/test/rules/imageRules.test.ts
+++ b/src/test/rules/imageRules.test.ts
@@ -1,15 +1,11 @@
 import * as assert from 'assert';
 import { validateImagesWithoutAlt } from '../../rules/imageRules';
-import { TestCase } from '../../rules/types';
-
-type ImageTestCase = TestCase<number> & {
-    category: 'Conforme' | 'Violacao' | 'Inaplicavel';
-};
+import { TestCase } from './testTypes';
 
 function runImageTests() {
     console.log("Iniciando Testes Unitarios: Regras de Acessibilidade de Imagem...");
 
-    const testCases: ImageTestCase[] = [
+    const testCases: TestCase<number>[] = [
         { name: "Atributo alt ausente", category: 'Violacao', html: '<img src="teste.png">', expected: 1 },
         { name: "Atributo alt vazio", category: 'Violacao', html: '<img src="teste.png" alt="">', expected: 1 },
         { name: "Alt valido", category: 'Conforme', html: '<img src="teste.png" alt="Descricao">', expected: 0 },

--- a/src/test/rules/justifyRules.test.ts
+++ b/src/test/rules/justifyRules.test.ts
@@ -1,41 +1,37 @@
 import * as assert from 'assert';
 import { validateJustifiedCss } from '../../rules/justifyRules';
-import { TestCase } from '../../rules/types';
-
-type JustifyTestCase = TestCase<number> & {
-  category: 'Conforme' | 'Violacao' | 'Inaplicavel';
-};
+import { TestCase } from './testTypes';
 
 function runJustifyRuleTests() {
-  console.log('Iniciando Testes Unitarios: Regra de Texto Justificado...');
+  console.log('Iniciando Testes Unitarios: Regra de Texto Justificado (CSS)...');
 
-  const testCases: JustifyTestCase[] = [
+  const testCases: TestCase<number>[] = [
     {
-      name: 'Sem text-align justify',
+      name: 'sem text-align justify',
       category: 'Conforme',
       html: 'p { text-align: left; }',
       expected: 0,
     },
     {
-      name: 'Com text-align justify simples',
+      name: 'com text-align justify simples',
       category: 'Violacao',
       html: '.content { text-align: justify; }',
       expected: 1,
     },
     {
-      name: 'Com letras maiusculas e espacos',
+      name: 'com letras maiusculas e espacos',
       category: 'Violacao',
       html: '.content { TEXT-ALIGN :   JUSTIFY; }',
       expected: 1,
     },
     {
-      name: 'Dois usos de justify',
+      name: 'dois usos de justify',
       category: 'Violacao',
       html: '.a { text-align: justify; } .b { text-align: justify; }',
       expected: 2,
     },
     {
-      name: 'Justify em comentario nao deve contar',
+      name: 'justify em comentario nao deve contar',
       category: 'Inaplicavel',
       html: '/* text-align: justify; */ .a { text-align: left; }',
       expected: 0,

--- a/src/test/rules/languageRules.test.ts
+++ b/src/test/rules/languageRules.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'assert';
+import { validatePageLanguage } from '../../rules/languageRules';
+import { TestCase } from './testTypes';
+
+function runLanguageRuleTests() {
+  console.log('Iniciando Testes Unitarios: Regra de Idioma da Pagina Ausente...');
+
+  const testCases: TestCase<number>[] = [
+    {
+      name: 'html com lang pt-BR',
+      category: 'Conforme',
+      html: '<!doctype html><html lang="pt-BR"><head></head><body></body></html>',
+      expected: 0,
+    },
+    {
+      name: 'html com lang en',
+      category: 'Conforme',
+      html: '<html lang="en"><body>Hello</body></html>',
+      expected: 0,
+    },
+    {
+      name: 'html em maiusculas com lang definido',
+      category: 'Conforme',
+      html: '<HTML lang="FR"><body>Bonjour</body></HTML>',
+      expected: 0,
+    },
+    {
+      name: 'html sem lang',
+      category: 'Violacao',
+      html: '<html><head></head><body></body></html>',
+      expected: 1,
+    },
+    {
+      name: 'html com lang vazio',
+      category: 'Violacao',
+      html: '<html lang=""><body></body></html>',
+      expected: 1,
+    },
+    {
+      name: 'html com lang contendo um espaco',
+      category: 'Violacao',
+      html: '<html lang=" "><body></body></html>',
+      expected: 1,
+    },
+    {
+      name: 'html com lang contendo apenas whitespace ASCII',
+      category: 'Violacao',
+      html: '<html lang=" \t\n\r "><body></body></html>',
+      expected: 1,
+    },
+    {
+      name: 'html com apenas xml:lang sem lang',
+      category: 'Violacao',
+      html: '<html xml:lang="en"><body></body></html>',
+      expected: 1,
+    },
+    {
+      name: 'conteudo sem tag html',
+      category: 'Inaplicavel',
+      html: '<div>Fragmento</div>',
+      expected: 0,
+    },
+  ];
+
+  let passedCount = 0;
+
+  testCases.forEach(testCase => {
+    const results = validatePageLanguage(testCase.html);
+    const observed = results.length;
+
+    try {
+      assert.strictEqual(observed, testCase.expected);
+      console.log(
+        `OK | Categoria: ${testCase.category} | Caso: ${testCase.name} | esperado=${testCase.expected} encontrado=${observed}`
+      );
+      passedCount++;
+    } catch (err) {
+      console.error(
+        `ERRO | Categoria: ${testCase.category} | Caso: ${testCase.name} | esperado=${testCase.expected} encontrado=${observed}`
+      );
+    }
+  });
+
+  console.log(`\nResultado Final: ${passedCount}/${testCases.length} testes passaram.\n`);
+
+  if (passedCount !== testCases.length) {
+    process.exit(1);
+  }
+}
+
+runLanguageRuleTests();

--- a/src/test/rules/nonInteractiveClickableRules.test.ts
+++ b/src/test/rules/nonInteractiveClickableRules.test.ts
@@ -1,15 +1,11 @@
 import * as assert from 'assert';
 import { validateNonInteractiveClickableElements } from '../../rules/nonInteractiveClickableRules';
-import { TestCase } from '../../rules/types';
-
-type NonInteractiveClickableTestCase = TestCase<number> & {
-  category: 'Conforme' | 'Violacao' | 'Inaplicavel';
-};
+import { TestCase } from './testTypes';
 
 function runNonInteractiveClickableTests() {
   console.log('Iniciando Testes Unitarios: Regra de Elementos Nao Interativos Clicaveis...');
 
-  const testCases: NonInteractiveClickableTestCase[] = [
+  const testCases: TestCase<number>[] = [
     {
       name: 'div com onclick sem role/tabindex',
       category: 'Violacao',

--- a/src/test/rules/testTypes.ts
+++ b/src/test/rules/testTypes.ts
@@ -1,0 +1,8 @@
+export type TestCategory = "Conforme" | "Violacao" | "Inaplicavel";
+
+export type TestCase<T = number> = {
+  name: string;
+  html: string;
+  expected: T;
+  category: TestCategory;
+};

--- a/src/test/rules/zoomRules.test.ts
+++ b/src/test/rules/zoomRules.test.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
 import { validateZoomCapability } from '../../rules/zoomRules';
-import { TestCase } from '../../rules/types';
+import { TestCase } from './testTypes';
 
 type ZoomTestCase = TestCase<number> & {
-  category: 'Conforme' | 'Violacao' | 'Inaplicavel';
   expectedMessageIncludes?: string[];
 };
 


### PR DESCRIPTION
Verificar se a tag raiz possui o atributo lang definido, essencial para que leitores de tela identifiquem o idioma correto da página.

Closes #9