### PR TITLE
US-01.9: Regra IDs Duplicados (HTML)

### DIFF
--- a/examples/duplicate-ids-test.html
+++ b/examples/duplicate-ids-test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Teste de IDs Duplicados</title>
+</head>
+
+<body>
+  <h1>Exemplo de IDs duplicados</h1>
+
+  <label for="email">E-mail</label>
+  <input id="email" type="email" />
+
+  <p id="email">Este id duplicado deve ser reportado pela regra.</p>
+</body>
+
+</html>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { validateNonInteractiveClickableElements } from './rules/nonInteractiveC
 import { validateFocusVisualRemoval } from './rules/focusRules';
 import { validateHtmlFocusVisible } from './rules/focusHtmlRules';
 import { validatePageLanguage } from './rules/languageRules';
+import { validateDuplicateIds } from './rules/duplicateIdsRules';
 import { RuleError } from './rules/types';
 
 let timeout: NodeJS.Timeout | undefined = undefined;
@@ -73,6 +74,7 @@ function processValidation(document: vscode.TextDocument): void {
 		errors.push(...validateNonInteractiveClickableElements(text));
 		errors.push(...validateHtmlFocusVisible(text));
 		errors.push(...validatePageLanguage(text));
+		errors.push(...validateDuplicateIds(text));
 	}
 
 	if (language === 'css') {

--- a/src/rules/duplicateIdsRules.ts
+++ b/src/rules/duplicateIdsRules.ts
@@ -1,0 +1,40 @@
+import { RuleError } from "./types";
+import { parseHtmlAttributes } from "./utils/htmlAttributes";
+
+// Captura tags de abertura HTML para verificar repeticao de IDs no documento.
+const OPENING_TAG_REGEX = /<([a-z][\w:-]*)\b[^>]*>/gi;
+
+/**
+ * Valida duplicidade de atributos id em elementos HTML.
+ * @param text O conteudo HTML a ser analisado.
+ */
+export function validateDuplicateIds(text: string): RuleError[] {
+  const errors: RuleError[] = [];
+  const seenIds = new Set<string>();
+
+  OPENING_TAG_REGEX.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = OPENING_TAG_REGEX.exec(text)) !== null) {
+    const entireTag = match[0];
+    const attrs = parseHtmlAttributes(entireTag);
+    const id = attrs["id"];
+
+    if (!id) {
+      continue;
+    }
+
+    if (seenIds.has(id)) {
+      errors.push({
+        tag: entireTag,
+        index: match.index,
+        message: `Erro de Acessibilidade: ID duplicado detectado (id=\"${id}\"). IDs devem ser unicos na pagina.`,
+      });
+      continue;
+    }
+
+    seenIds.add(id);
+  }
+
+  return errors;
+}

--- a/src/test/rules/duplicateIdsRules.test.ts
+++ b/src/test/rules/duplicateIdsRules.test.ts
@@ -1,0 +1,67 @@
+import * as assert from 'assert';
+import { validateDuplicateIds } from '../../rules/duplicateIdsRules';
+import { TestCase } from './testTypes';
+
+function runDuplicateIdsRuleTests() {
+  console.log('Iniciando Testes Unitarios: Regra de IDs Duplicados (HTML)...');
+
+  const testCases: TestCase<number>[] = [
+    {
+      name: 'ids unicos no documento',
+      category: 'Conforme',
+      html: '<div id="header"></div><main id="content"></main><footer id="footer"></footer>',
+      expected: 0,
+    },
+    {
+      name: 'um id duplicado (segunda ocorrencia)',
+      category: 'Violacao',
+      html: '<div id="menu"></div><nav id="menu"></nav>',
+      expected: 1,
+    },
+    {
+      name: 'id repetido tres vezes (duas ocorrencias invalidas)',
+      category: 'Violacao',
+      html: '<section id="item"></section><article id="item"></article><aside id="item"></aside>',
+      expected: 2,
+    },
+    {
+      name: 'elementos sem id',
+      category: 'Inaplicavel',
+      html: '<div></div><p>Texto</p>',
+      expected: 0,
+    },
+    {
+      name: 'id vazio nao conta como duplicidade',
+      category: 'Inaplicavel',
+      html: '<div id=""></div><span id=""></span>',
+      expected: 0,
+    },
+  ];
+
+  let passedCount = 0;
+
+  testCases.forEach(testCase => {
+    const results = validateDuplicateIds(testCase.html);
+    const observed = results.length;
+
+    try {
+      assert.strictEqual(observed, testCase.expected);
+      console.log(
+        `OK | Categoria: ${testCase.category} | Caso: ${testCase.name} | esperado=${testCase.expected} encontrado=${observed}`
+      );
+      passedCount++;
+    } catch (err) {
+      console.error(
+        `ERRO | Categoria: ${testCase.category} | Caso: ${testCase.name} | esperado=${testCase.expected} encontrado=${observed}`
+      );
+    }
+  });
+
+  console.log(`\nResultado Final: ${passedCount}/${testCases.length} testes passaram.\n`);
+
+  if (passedCount !== testCases.length) {
+    process.exit(1);
+  }
+}
+
+runDuplicateIdsRuleTests();


### PR DESCRIPTION
Implementar rastreio de unicidade de atributos id no documento, garantindo que não existam referências duplicadas que quebrem a árvore de acessibilidade.

Closes #10 