### PR TITLE
US-01.10: Configuração de DiagnosticCollection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,14 +11,23 @@ import { validateDuplicateIds } from './rules/duplicateIdsRules';
 import { RuleError } from './rules/types';
 
 let timeout: NodeJS.Timeout | undefined = undefined;
+let diagnosticsCollection: vscode.DiagnosticCollection | undefined = undefined;
 
+/**
+ * Inicializa a extensao, registra a collection de diagnosticos e configura
+ * os eventos para validar documentos HTML/CSS em tempo real.
+ */
 export function activate(context: vscode.ExtensionContext) {
 	console.log('A11y Assistant Funcionando.');
+	diagnosticsCollection = vscode.languages.createDiagnosticCollection('a11y-vsc-assistant');
+	context.subscriptions.push(diagnosticsCollection);
 
 	if (vscode.window.activeTextEditor) {
 		const doc = vscode.window.activeTextEditor.document;
 		if (isFileExtensionValid(doc)) {
 			processValidation(doc);
+		} else {
+			clearDiagnostics(doc);
 		}
 	}
 
@@ -33,6 +42,8 @@ export function activate(context: vscode.ExtensionContext) {
 			timeout = setTimeout(() => {
 				processValidation(document);
 			}, 500);
+		} else {
+			clearDiagnostics(document);
 		}
 	});
 
@@ -44,6 +55,8 @@ export function activate(context: vscode.ExtensionContext) {
 		const document = editor.document;
 		if (isFileExtensionValid(document)) {
 			processValidation(document);
+		} else {
+			clearDiagnostics(document);
 		}
 	});
 
@@ -51,16 +64,22 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(activeEditorChangeEvent);
 }
 
+/**
+ * Libera recursos ao desativar a extensao.
+ */
 export function deactivate() {
 	if (timeout) {
 		clearTimeout(timeout);
 	}
+
+	diagnosticsCollection?.clear();
+	diagnosticsCollection = undefined;
 }
 
-function isFileExtensionValid(document: vscode.TextDocument): boolean {
-	return document.languageId === 'html' || document.languageId === 'css';
-}
-
+/**
+ * Executa as regras de acessibilidade conforme a linguagem do documento,
+ * publica os diagnosticos no editor e registra os erros no console.
+ */
 function processValidation(document: vscode.TextDocument): void {
 	const text = document.getText();
 	const language = document.languageId;
@@ -82,8 +101,52 @@ function processValidation(document: vscode.TextDocument): void {
 		errors.push(...validateFocusVisualRemoval(text));
 	}
 
+	const diagnostics = mapRuleErrorsToDiagnostics(document, errors);
+	diagnosticsCollection?.set(document.uri, diagnostics);
+
 	errors.forEach(error => {
 		const startPosition = document.positionAt(error.index);
 		console.log(`[Linha ${startPosition.line + 1}] ${error.message}`);
 	});
+}
+
+/**
+ * Converte os erros de regra internos para Diagnostic do VS Code,
+ * calculando range com base no indice e no tamanho da tag capturada.
+ */
+function mapRuleErrorsToDiagnostics(document: vscode.TextDocument, errors: RuleError[]): vscode.Diagnostic[] {
+	const textLength = document.getText().length;
+
+	return errors.map(error => {
+		const startOffset = Math.max(0, Math.min(error.index, textLength));
+		const rawTagLength = error.tag?.length ?? 0;
+		let endOffset = Math.max(startOffset, Math.min(startOffset + Math.max(rawTagLength, 1), textLength));
+
+		if (endOffset === startOffset && startOffset < textLength) {
+			endOffset = startOffset + 1;
+		}
+
+		const range = new vscode.Range(
+			document.positionAt(startOffset),
+			document.positionAt(endOffset)
+		);
+
+		const diagnostic = new vscode.Diagnostic(range, error.message, vscode.DiagnosticSeverity.Warning);
+		diagnostic.source = 'A11y Assistant';
+		return diagnostic;
+	});
+}
+
+/**
+ * Verifica se o documento e de uma linguagem suportada pelo motor de regras.
+ */
+function isFileExtensionValid(document: vscode.TextDocument): boolean {
+	return document.languageId === 'html' || document.languageId === 'css';
+}
+
+/**
+ * Remove diagnosticos previamente publicados para um documento.
+ */
+function clearDiagnostics(document: vscode.TextDocument): void {
+	diagnosticsCollection?.delete(document.uri);
 }

--- a/src/rules/focusRules.ts
+++ b/src/rules/focusRules.ts
@@ -63,7 +63,7 @@ export function validateFocusVisualRemoval(text: string): RuleError[] {
     let outlineMatch: RegExpExecArray | null;
     while ((outlineMatch = OUTLINE_REMOVAL_REGEX.exec(declarations)) !== null) {
       errors.push({
-        tag: `${selector} { ${outlineMatch[0]} }`,
+        tag: outlineMatch[0],
         index: declarationsStartIndex + outlineMatch.index,
         message: "Erro de Acessibilidade: Evite remover o foco visual (outline: none/0) sem indicador alternativo visivel.",
       });


### PR DESCRIPTION
Integrar os resultados do motor de regras ao objeto languages.createDiagnosticCollection, mapeando o erro à linha/coluna exata para renderizar o sublinhado no editor.

Closes #11